### PR TITLE
Use scheme relative URLs for resources

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -5,27 +5,27 @@
 		<title>xHain hack+makerspace</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1">			 
     	<link rel="stylesheet" 
-    			href="http://xhain-hackspace.github.io/css/bootstrap.min.css" >
+    			href="//xhain-hackspace.github.io/css/bootstrap.min.css" >
 		<link rel="stylesheet" 
-			  href="http://xhain-hackspace.github.io/css/style.css">	
+			  href="//xhain-hackspace.github.io/css/style.css">	
 	</head>     
 	<body>
 		<header>
 			<p>
-				<a href="http://xhain-hackspace.github.io/index.html">
-				<img src="http://xhain-hackspace.github.io/xHain_logo.png" alt="xHain hack+makerspace">
+				<a href="//xhain-hackspace.github.io/index.html">
+				<img src="//xhain-hackspace.github.io/xHain_logo.png" alt="xHain hack+makerspace">
 				</a>
 			</p>
 			<nav>
 				<ul>
 	             	<li>
-	             		<a href="http://xhain-hackspace.github.io/calender.html">anstehendes</a>
+	             		<a href="//xhain-hackspace.github.io/calender.html">anstehendes</a>
 	             	</li>
 	             	<li>
-	             		<a href="http://xhain-hackspace.github.io/support.html">unterstützendes</a>
+	             		<a href="//xhain-hackspace.github.io/support.html">unterstützendes</a>
 	             	</li>
 	           		<li>
-	           			<a href="http://xhain-hackspace.github.io/about.html">informierendes</a>
+	           			<a href="//xhain-hackspace.github.io/about.html">informierendes</a>
 	           		</li>
 	    		</ul>
 	    	</nav>		
@@ -50,10 +50,10 @@
 	 		Grünberger Straße 14  <br>
 	 		10243 Berlin<br><br>	 		
 			<a href="https://twitter.com/xHain_hackspace" >
-	 			<img src="http://xhain-hackspace.github.io/Twitter_logo.jpg" alt="xHain hack+makerspace" height="16" width="16" title="Twitter">
+	 			<img src="//xhain-hackspace.github.io/Twitter_logo.jpg" alt="xHain hack+makerspace" height="16" width="16" title="Twitter">
 			</a>
 			<a href="mailto:x-hain@posteo.de?subject=Newsletter%20abonnieren">
-	 			<img src="http://xhain-hackspace.github.io/Mail_Icon.png" alt="xHain hack+makerspace" height="24" width="24" title="Newsletter">
+	 			<img src="//xhain-hackspace.github.io/Mail_Icon.png" alt="xHain hack+makerspace" height="24" width="24" title="Newsletter">
 			</a>
 	 	</p>
 	 </footer>


### PR DESCRIPTION
This avoids mixed-content warnings and unloaded resources when accessing the page via HTTPS
github.io supports HTTPS and extensions like HTTPS Everywhere use it automatically.
