### PR TITLE
Remove duplicate markup and filter blog posts by language

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 _site/
+.jekyll-metadata

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,5 +1,5 @@
 <p>
-	<a href="./"><img src="/xHain_logo.png" alt="xHain hack+makespace"></a>
+	<a href="/{% if page.lang != 'de' %}{{ page.lang }}{% endif %}"><img src="/xHain_logo.png" alt="xHain hack+makespace"></a>
 </p>
 {% if page.lang == 'en' %}
 <nav>

--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -4,47 +4,40 @@
 		<meta charset="UTF-8">
 		<title>xHain hack+makespace</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1">			 
-    	<link rel="stylesheet" 
-    			href="{{site.url}}/css/bootstrap.min.css" >
-		<link rel="stylesheet" 
-			  href="{{site.url}}/css/style.css">	
-	</head>     
+		<link rel="stylesheet" href="/css/bootstrap.min.css" >
+		<link rel="stylesheet" href="/css/style.css">	
+	</head>
 	<body>
 		<header>
 			{% include navigation.html %}
 		</header>
-			<div class="container">
-				<div class="row">
-					<div class="col-md-3"></div>
-					<div class="col-md-6">
-						<section>
-								<article>
-									{{ page.content }}
-								</article>
-							<section>	
-								{% for post in site.posts %}
-									<h3><a href="{{ post.url }}"> {{ post.title }} </a></h3>
-									{{ post.excerpt }}
-									<a href="{{ post.url }}"  class="center">[weiter...]</a>
-								{% endfor %}
-							</section>
-						</section> 
-					</div>
-					<div class="col-md-3"></div>
+
+		<div class="container">
+			<div class="row">
+				<div class="col-md-3"></div>
+				<div class="col-md-6">
+					<section>
+						<article>
+							{{ page.content }}
+						</article>
+					</section> 
 				</div>
-			</div>  			
-	 <footer>
-	 	<p>
-	 		xHain hack+makespace <br>
-	 		Grünberger Straße 14  <br>
-	 		10243 Berlin<br><br>	 		
+				<div class="col-md-3"></div>
+			</div>
+		</div>
+
+		<footer>
+			<p>
+				xHain hack+makespace<br>
+				Grünberger Straße 14<br>
+				10243 Berlin<br><br>
 				<a href="https://twitter.com/xHain_hackspace" >
-		 			<img src="{{site.url}}/Twitter_logo.jpg" alt="xHain hack+makespace" height="16" width="16" title="Twitter">
+					<img src="{{site.url}}/Twitter_logo.jpg" alt="xHain hack+makespace" height="16" width="16" title="Twitter">
 				</a>
 				<a href="mailto:x-hain@posteo.de?subject=Newsletter%20abonnieren">
-		 			<img src="{{site.url}}/Mail_Icon.png" alt="xHain hack+makespace" height="24" width="24" title="Newsletter">
+					<img src="{{site.url}}/Mail_Icon.png" alt="xHain hack+makespace" height="24" width="24" title="Newsletter">
 				</a>
-	 	</p>
-	 </footer>
+		 	</p>
+		 </footer>
 	 </body>
 </html>

--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -18,7 +18,7 @@
 				<div class="col-md-6">
 					<section>
 						<article>
-							{{ page.content }}
+							{{ content }}
 						</article>
 					</section> 
 				</div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,61 +1,6 @@
-<!DOCTYPE html>
-<html lang="en-us">
-	<head>
-		<meta charset="UTF-8">
-		<title>xHain hack+makespace</title>
-		<meta name="viewport" content="width=device-width, initial-scale=1">			 
-    	<link rel="stylesheet" 
-    			href="{{site.url}}/css/bootstrap.min.css" >
-		<link rel="stylesheet" 
-			  href="{{site.url}}/css/style.css">	
-	</head>     
-	<body>
-		<header>
-			<p>
-				<a href="//xhain-hackspace.github.io/index.html">
-				<img src="//xhain-hackspace.github.io/xHain_logo.png" alt="xHain hack+makespace">
-				</a>
-			</p>
-			<nav>
-				<ul>
-	             	<li>
-	            		<a href="{{site.url}}/calender.html" class="{% if page.url == '/calender.html' %}current{% endif %}">anstehendes</a>
-	             	</li>
-	             	<li>
-	             		<a href="{{site.url}}/support.html" class="{% if page.url == '/support.html' %}current{% endif %}">unterstützendes</a>
-	             	</li>
-	           		<li>
-	             		<a href="{{site.url}}/about.html" class="{% if page.url == 'about.html' %}current{% endif %}">informierendes</a>
-	           		</li>
-	    		</ul>
-	    	</nav>		
-		</header>
-			<div class="container">
-				<div class="row">
-					<div class="col-md-2"></div>
-					<div class="col-md-8">
-						<section>
-								<article>
-									<h3>{{ page.title }}</h3>
-									{{ page.content | markdownify }}
-								</article>
-							</section> 
-					</div>
-					<div class="col-md-2"></div>
-				</div>
-			</div>  			
-	 <footer>
-	 	<p>
-	 		xHain hack+makespace <br>
-	 		Grünberger Straße 14  <br>
-	 		10243 Berlin<br><br>	 		
-				<a href="https://twitter.com/xHain_hackspace" >
-		 			<img src="{{site.url}}/Twitter_logo.jpg" alt="xHain hack+makespace" height="16" width="16" title="Twitter">
-				</a>
-				<a href="mailto:x-hain@posteo.de?subject=Newsletter%20abonnieren">
-		 			<img src="{{site.url}}/Mail_Icon.png" alt="xHain hack+makespace" height="24" width="24" title="Newsletter">
-				</a>
-	 	</p>
-	 </footer>
-	 </body>
-</html>
+---
+layout: main
+---
+<h3>{{ page.title }}</h3>
+
+{{ content }}

--- a/_posts/2016-04-18-hackspace statt Angst - Eröffnung am Freitag, den 13. Mai 2016.en.md
+++ b/_posts/2016-04-18-hackspace statt Angst - Eröffnung am Freitag, den 13. Mai 2016.en.md
@@ -1,0 +1,13 @@
+---
+layout: post
+title: hackspace > fear – Opening on Friday, 13 May 2016
+meta: short description
+category: news
+lang: en
+permalink: /en/news/2016/04/18/opening.html
+---
+We're celebrating the opening of xHain on Friday, 13 May!
+
+Doors open at 6pm.  
+Come over, have a look at what we've made of the once bare room and snag a sticker!  
+Music and drinks are available.

--- a/_posts/2016-04-18-hackspace statt Angst - Eröffnung am Freitag, den 13. Mai 2016.md
+++ b/_posts/2016-04-18-hackspace statt Angst - Eröffnung am Freitag, den 13. Mai 2016.md
@@ -3,6 +3,7 @@ layout: post
 title: hackspace statt Angst - Eröffnung am Freitag, den 13. Mai 2016
 meta: short description
 category: news
+lang: de
 ---
 <p> Am Freitag, den 13. Mai feiern wir die Eröffnung des xHains! <br> Ab 18Uhr steht Euch die Tür offen. <br> Kommt vorbei und schaut euch an was aus dem kahlen Raum geworden ist und kassiert einen Aufkleber ein. <br>
 Musik und Getränke gibt es natürlich auch.

--- a/about.en.html
+++ b/about.en.html
@@ -1,62 +1,22 @@
 ---
 lang: en
 permalink: /en/about.html
+layout: main
 ---
-<!DOCTYPE html>
-<html lang="en">
-	<head>
-		<meta charset="UTF-8">
-		<title>xHain hack+makespace</title>
-		<meta name="viewport" content="width=device-width, initial-scale=1">			 
-    	<link rel="stylesheet" 
-    			href="/css/bootstrap.min.css" >
-		<link rel="stylesheet" 
-			  href="/css/style.css">	
-	</head>
-    
-	<body>
-		<header>
-			{% include navigation.html %}
-		</header>
-
-			<div class="container">
-				<div class="row">
-					<div class="col-md-2"></div>
-					<div class="col-md-8">
-		 	<h3>The Idea</h3>
-		 	<p>
-			To have a local place for exchanges, mutual learning and fun: that’s the vision for xHain.
-			During the day: a place where projects and school groups can learn.
-			At night: a place where hackers and makers can meet.
-			At other times: a conference room or a temporary desk for Friedrichshainers with no office to go to.
-			This – or something similar – is what founder Felix hopes xHain turns out to be.
-			</p>
-			<h3>Who It’s For</h3>
-			<p>
-			We want to create a place where makers, people who are interested in tech, and (society) hackers feel comfortable.
-			You’re welcome no matter who you are or what you do – whether you have a job or not, whether you’re a trainee or a student, a single parent or a senior citizen.
-			</p>
-			<p>
-			xHain is a non-smoking place. People who want to smoke can do so outside.
-			If you’re sexist, racist, homophobic or an asshole, please don’t bother coming.
-			</p>
-<h3>Contact</h3>
-		 	<p>
-		 	xHain hack+makespace <br>
-		 		Felix J. Just         <br>
-		 		Grünberger Straße 14  <br>
-		 		10243 Berlin		  <br><br>	 			
-		 		Email: x-hain at posteo.de <br><br>
-				<a href="https://twitter.com/xHain_hackspace" >
-		 			<img src="/Twitter_logo.jpg" alt="xHain hack+makespace" height="16" width="16" title="Twitter">
-				</a>
-				<a href="mailto:x-hain@posteo.de">
-		 			<img src="/Mail_Icon.png" alt="xHain hack+makespace" height="24" width="24" title="Mail">
-				</a>
-	 		</p>
-					</div>
-					<div class="col-md-2"></div>
-				</div>
-			</div>  		
-	</body>
-</html>
+<h3>The Idea</h3>
+<p>
+To have a local place for exchanges, mutual learning and fun: that’s the vision for xHain.
+During the day: a place where projects and school groups can learn.
+At night: a place where hackers and makers can meet.
+At other times: a conference room or a temporary desk for Friedrichshainers with no office to go to.
+This – or something similar – is what founder Felix hopes xHain turns out to be.
+</p>
+<h3>Who It’s For</h3>
+<p>
+We want to create a place where makers, people who are interested in tech, and (society) hackers feel comfortable.
+You’re welcome no matter who you are or what you do – whether you have a job or not, whether you’re a trainee or a student, a single parent or a senior citizen.
+</p>
+<p>
+xHain is a non-smoking place. People who want to smoke can do so outside.
+If you’re sexist, racist, homophobic or an asshole, please don’t bother coming.
+</p>

--- a/about.html
+++ b/about.html
@@ -1,54 +1,14 @@
 ---
 lang: de
+layout: main
 ---
-<!DOCTYPE html>
-<html lang="de">
-	<head>
-		<meta charset="UTF-8">
-		<title>xHain hack+makespace</title>
-		<meta name="viewport" content="width=device-width, initial-scale=1">			 
-    	<link rel="stylesheet" 
-    			href="/css/bootstrap.min.css" >
-		<link rel="stylesheet" 
-			  href="/css/style.css">	
-	</head>
-    
-	<body>
-		<header>
-			{% include navigation.html %}
-		</header>
-
-			<div class="container">
-				<div class="row">
-					<div class="col-md-2"></div>
-					<div class="col-md-8">
-		 	<h3>Die Idee</h3>
-		 	<p>
-			Ein Ort im Kiez, der sich für Austausch, gegenseitige Schulung und gute Laune eignet: So soll der xHain werden. 
-			Tagsüber: Ein Lernort für Projekt- und Schülergruppen. Abends: Ein Treffpunkt für Hackerinnen und Bastler. Zwischendurch: Ein Tagungsraum oder temporärer Schreibtisch für bürolose Friedrichshainer/innen. So oder ähnlich könnte sich der xHain, wenn es nach Gründer Felix geht, entwickeln.
-			</p>
-			<h3>Die Nutzer/innen</h3>
-			<p>Wir möchten mit dem xHain einen Ort schaffen, an dem sich Bastlerinnen, Technikinteressierte und (Gesellschafts-)hacker wohl fühlen. Damit sind nicht nur Berufstätige, sondern auch Azubis, Erwerbslose, Schülerinnen und gern auch Senioren gemeint. <br>
-			Der xHain ist ein rauchfreier Ort. Wer rauchen will, kann das draußen tun.
-			Wer sexistisch, rassistisch, homophob oder ein Arschloch ist, braucht nicht zu kommen.
-			</p>
-<h3>Kontakt</h3>
-		 	<p>
-		 	xHain hack+makespace <br>
-		 		Felix J. Just         <br>
-		 		Grünberger Straße 14  <br>
-		 		10243 Berlin		  <br><br>	 		
-		 		Email: x-hain at posteo.de <br><br>
-				<a href="https://twitter.com/xHain_hackspace" >
-		 			<img src="Twitter_logo.jpg" alt="xHain hack+makespace" height="16" width="16" title="Twitter">
-				</a>
-				<a href="mailto:x-hain@posteo.de">
-		 			<img src="Mail_Icon.png" alt="xHain hack+makespace" height="24" width="24" title="Email">
-				</a>
-	 		</p>
-					</div>
-					<div class="col-md-2"></div>
-				</div>
-			</div>  		
-	</body>
-</html>
+<h3>Die Idee</h3>
+<p>
+Ein Ort im Kiez, der sich für Austausch, gegenseitige Schulung und gute Laune eignet: So soll der xHain werden. 
+Tagsüber: Ein Lernort für Projekt- und Schülergruppen. Abends: Ein Treffpunkt für Hackerinnen und Bastler. Zwischendurch: Ein Tagungsraum oder temporärer Schreibtisch für bürolose Friedrichshainer/innen. So oder ähnlich könnte sich der xHain, wenn es nach Gründer Felix geht, entwickeln.
+</p>
+<h3>Die Nutzer/innen</h3>
+<p>Wir möchten mit dem xHain einen Ort schaffen, an dem sich Bastlerinnen, Technikinteressierte und (Gesellschafts-)hacker wohl fühlen. Damit sind nicht nur Berufstätige, sondern auch Azubis, Erwerbslose, Schülerinnen und gern auch Senioren gemeint. <br>
+Der xHain ist ein rauchfreier Ort. Wer rauchen will, kann das draußen tun.
+Wer sexistisch, rassistisch, homophob oder ein Arschloch ist, braucht nicht zu kommen.
+</p>

--- a/calendar.en.html
+++ b/calendar.en.html
@@ -1,66 +1,29 @@
 ---
 lang: en
 permalink: /en/calendar.html
+layout: main
 ---
-<!DOCTYPE html>
-<html lang="en">
-	<head>
-		<meta charset="UTF-8">
-		<title>xHain hack+makespace</title>
-		<meta name="viewport" content="width=device-width, initial-scale=1">			 
-    	<link rel="stylesheet" 
-    			href="/css/bootstrap.min.css" >
-		<link rel="stylesheet" 
-			  href="/css/style.css">	
-	</head>     
-	<body>
-		<header>
-			{% include navigation.html %}
-		</header>
-			<div class="container">
-				<div class="row">
-					<div class="col-md-2"></div>
-					<div class="col-md-8">
-						<ul>
-							<li><h2>May 2016</h2></li>
-							<li>
-								<p>Th, 19 May <br>ladies' salon by @heartsofcode</p>
-								<p>21 May, time <abbr title="to be determined">t.b.d.</abbr><br>
-									Soldering workshop for women</p>
-								<p>Mo, 23 May from 8:30pm<br>open grove</p>
-								<p>Th, 25 May <br>ladies' salon by @heartsofcode</p>
-								<p>Mo, 30 May from 5pm<br>open grove</p>
-							</li>
-						</ul>
-						<ul>
-							<li><h2>June 2016</h2></li>	
-							<li>
-								<p>Th, 2 June <br>ladies' salon by @heartsofcode</p>
-								<p>Mo, 6 June <br>open grove</p>
-								<p>Th, 9 June <br>ladies' salon by @heartsofcode</p>
-								<p>Mo, 13 June <br>open grove</p>
-								<p>Th, 15 June <br>ladies' salon by @heartsofcode</p>
-								<p>Mo, 20 June <br>open grove</p>
-								<p>Th, 22 June <br>ladies' salon by @heartsofcode</p>
-								<p>Mo, 27 June <br>open grove</p>
-							</li>
-						</ul> 
-					</div>
-					<div class="col-md-2"></div>
-				</div>
-			</div>  			
-		<footer>
-		 	<p>
-		 		xHain hack+makespace <br>
-		 		Grünberger Straße 14  <br>
-		 		10243 Berlin<br><br>	 		
-				<a href="https://twitter.com/xHain_hackspace" >
-		 			<img src="/Twitter_logo.jpg" alt="xHain hack+makespace" height="16" width="16" title="Twitter">
-				</a>
-				<a href="mailto:x-hain@posteo.de?subject=Newsletter%20abonnieren">
-		 			<img src="/Mail_Icon.png" alt="xHain hack+makespace" height="24" width="24" title="Newsletter">
-				</a>
-		 	</p>
-		</footer>
-	</body>
-</html>
+<ul>
+	<li><h2>May 2016</h2></li>
+	<li>
+		<p>Th, 19 May <br>ladies' salon by @heartsofcode</p>
+		<p>21 May, time <abbr title="to be determined">t.b.d.</abbr><br>
+			Soldering workshop for women</p>
+		<p>Mo, 23 May from 8:30pm<br>open grove</p>
+		<p>Th, 25 May <br>ladies' salon by @heartsofcode</p>
+		<p>Mo, 30 May from 5pm<br>open grove</p>
+	</li>
+</ul>
+<ul>
+	<li><h2>June 2016</h2></li>	
+	<li>
+		<p>Th, 2 June <br>ladies' salon by @heartsofcode</p>
+		<p>Mo, 6 June <br>open grove</p>
+		<p>Th, 9 June <br>ladies' salon by @heartsofcode</p>
+		<p>Mo, 13 June <br>open grove</p>
+		<p>Th, 15 June <br>ladies' salon by @heartsofcode</p>
+		<p>Mo, 20 June <br>open grove</p>
+		<p>Th, 22 June <br>ladies' salon by @heartsofcode</p>
+		<p>Mo, 27 June <br>open grove</p>
+	</li>
+</ul> 

--- a/calender.html
+++ b/calender.html
@@ -1,64 +1,27 @@
 ---
 lang: de
+layout: main
 ---
-<!DOCTYPE html>
-<html lang="de">
-	<head>
-		<meta charset="UTF-8">
-		<title>xHain hack+makespace</title>
-		<meta name="viewport" content="width=device-width, initial-scale=1">			 
-    	<link rel="stylesheet" 
-    			href="css/bootstrap.min.css" >
-		<link rel="stylesheet" 
-			  href="css/style.css">	
-	</head>     
-	<body>
-		<header>
-			{% include navigation.html %}
-		</header>
-			<div class="container">
-				<div class="row">
-					<div class="col-md-2"></div>
-					<div class="col-md-8">
-						<ul>
-							<li><h2>Mai 2016</h2></li>
-							<li>
-								<p>Do, 19.5. <br>Damensalon der @heartsofcode</p>
-								<p>Sa, 21.5. <br>Löt-Workshop für Mädels</p>
-								<p>Mo, 23.5. ab 20:30<br>offener Hain</p>
-								<p>Do, 25.5. <br>Damensalon der @heartsofcode</p>
-								<p>Mo, 30.5. ab 17:00<br>offener Hain</p>
-							</li>
-						</ul>
-						<ul>
-							<li><h2>Juni 2016</h2></li>	
-							<li>
-								<p>Do, 2.6. <br>Damensalon der @heartsofcode</p>
-								<p>Mo, 6.6. <br>offener Hain</p>
-								<p>Do, 9.6. <br>Damensalon der @heartsofcode</p>
-								<p>Mo, 13.6. <br>offener Hain</p>
-								<p>Do, 15.6. <br>Damensalon der @heartsofcode</p>
-								<p>Mo, 20.6. <br>offener Hain</p>
-								<p>Do, 22.6. <br>Damensalon der @heartsofcode</p>
-								<p>Mo, 27.6. <br>offener Hain</p>
-							</li>
-						</ul> 
-					</div>
-					<div class="col-md-2"></div>
-				</div>
-			</div>  			
-		<footer>
-		 	<p>
-		 		xHain hack+makespace <br>
-		 		Grünberger Straße 14  <br>
-		 		10243 Berlin<br><br>	 		
-				<a href="https://twitter.com/xHain_hackspace" >
-		 			<img src="Twitter_logo.jpg" alt="xHain hack+makespace" height="16" width="16" title="Twitter">
-				</a>
-				<a href="mailto:x-hain@posteo.de?subject=Newsletter%20abonnieren">
-		 			<img src="Mail_Icon.png" alt="xHain hack+makespace" height="24" width="24" title="Newsletter">
-				</a>
-		 	</p>
-		</footer>
-	</body>
-</html>
+<ul>
+	<li><h2>Mai 2016</h2></li>
+	<li>
+		<p>Do, 19.5. <br>Damensalon der @heartsofcode</p>
+		<p>Sa, 21.5. <br>Löt-Workshop für Mädels</p>
+		<p>Mo, 23.5. ab 20:30<br>offener Hain</p>
+		<p>Do, 25.5. <br>Damensalon der @heartsofcode</p>
+		<p>Mo, 30.5. ab 17:00<br>offener Hain</p>
+	</li>
+</ul>
+<ul>
+	<li><h2>Juni 2016</h2></li>	
+	<li>
+		<p>Do, 2.6. <br>Damensalon der @heartsofcode</p>
+		<p>Mo, 6.6. <br>offener Hain</p>
+		<p>Do, 9.6. <br>Damensalon der @heartsofcode</p>
+		<p>Mo, 13.6. <br>offener Hain</p>
+		<p>Do, 15.6. <br>Damensalon der @heartsofcode</p>
+		<p>Mo, 20.6. <br>offener Hain</p>
+		<p>Do, 22.6. <br>Damensalon der @heartsofcode</p>
+		<p>Mo, 27.6. <br>offener Hain</p>
+	</li>
+</ul> 

--- a/index.en.html
+++ b/index.en.html
@@ -5,7 +5,9 @@ lang: en
 permalink: /en/
 ---
 {% for post in site.posts %}
+{% if post.lang == page.lang %}
 	<h3><a href="{{ post.url }}"> {{ post.title }} </a></h3>
 	{{ post.excerpt }}
-	<a href="{{ post.url }}"  class="center">[read on...]</a>
+	<a href="{{ post.url }}"  class="center">[read on…]</a>
+{% endif %}
 {% endfor %}

--- a/index.en.html
+++ b/index.en.html
@@ -4,3 +4,8 @@ title: xHain hack+makespace
 lang: en
 permalink: /en/
 ---
+{% for post in site.posts %}
+	<h3><a href="{{ post.url }}"> {{ post.title }} </a></h3>
+	{{ post.excerpt }}
+	<a href="{{ post.url }}"  class="center">[read on...]</a>
+{% endfor %}

--- a/index.html
+++ b/index.html
@@ -2,3 +2,8 @@
 layout: main
 title: xHain hack+makespace
 ---
+{% for post in site.posts %}
+	<h3><a href="{{ post.url }}"> {{ post.title }} </a></h3>
+	{{ post.excerpt }}
+	<a href="{{ post.url }}"  class="center">[weiter...]</a>
+{% endfor %}

--- a/index.html
+++ b/index.html
@@ -1,9 +1,12 @@
 ---
 layout: main
 title: xHain hack+makespace
+lang: de
 ---
 {% for post in site.posts %}
+{% if post.lang == page.lang %}
 	<h3><a href="{{ post.url }}"> {{ post.title }} </a></h3>
 	{{ post.excerpt }}
-	<a href="{{ post.url }}"  class="center">[weiter...]</a>
+	<a href="{{ post.url }}"  class="center">[weiter…]</a>
+{% endif %}
 {% endfor %}

--- a/support.en.html
+++ b/support.en.html
@@ -1,72 +1,31 @@
 ---
 lang: en
 permalink: /en/support.html
+layout: main
 ---
-<!DOCTYPE html>
-<html lang="en">
-	<head>
-		<meta charset="UTF-8">
-		<title>xHain hack+makespace</title>
-		<meta name="viewport" content="width=device-width, initial-scale=1">			 
-    	<link rel="stylesheet" 
-    			href="/css/bootstrap.min.css" >
-		<link rel="stylesheet" 
-			  href="/css/style.css">	
-	</head>
-	<body>
-		<header>
-			{% include navigation.html %}
-		</header>
-			<div class="container">
-				<div class="row">
-					<div class="col-md-2"></div>
-					<div class="col-md-8 center">
-						<section>
-							<article>
-								<p>
-									<br>
-									There are several ways to support xHain. As we’ve only just started building the place, there are two main things you can contribute: time and money.
-								</p>
-								<h3>Coming Over</h3>
-								<p>
-									Come over and help us! There are still shelves and tables to be built, a bathroom to be wallpapered, chairs to be painted, a cable harness to be built, window blinds to be put up, and things to be done in general. All helping hands are welcome! If you have one or two to spare, shoot Felix an email (<a href="mailto:x-hain@posteo.de">x-hain@posteo.de</a>) or tweet to us <a href="https://twitter.com/xHain_hackspace">@xhain_hackspace</a>.
-								</p>
-								<h3>Support Rate</h3>
-								<p>
-									If you think it’s good and important to have a hackspace in Friedrichshain, support us! Our support rate sets you back €13.37 a month.
-									In return, you get discounts on everything we’ll have to offer in future. We’re planning to have t-shirts, workshops, training sessions, 3D prints and lots more. Supporters are also free to use our tools and devices such as the 3D printer.
-									If the support rate is beyond your means, talk to us and we’ll find a way.
-									Of course, you’re also free to support us with more than €13.37 and help sponsor somebody else’s membership.
-								</p>
-								<p>
-									Running a hackspace isn’t free: we need to pay rent, electricity, internet and other niceties. All proceeds from the support rate go towards our running costs. Should there be a surplus, we’ll use it to buy more tools and devices that keep turning our hackspace into <em>the</em> place to go for all tech enthusiasts in Friedrichshain.
-								</p>
-								<h3>Renting the Place</h3>
-								<p>
-									You can rent xHain for a small conference or an event. There’s not enough room for huge birthday parties, but if you’re planning a workshop, if you’re looking for a less conventional place for your meetings, if you want to screen your movie or if you’re looking for a creative environment where you can write your fan fiction, just contact us and we’ll work out the details.
-								</p>
-								<h3>Donating Equipment</h3>
-								<p>
-									If your laser cutters, soldering stations, 3D printers, screwdrivers, Arduinos, Raspberry Pis, rad1o badges or webcams are only collecting dust: give them to us! We’re thrilled to give a new home to all your old-but-functional gadgets and devices.
-								</p>
-							</article>
-						</section> 
-					</div>
-					<div class="col-md-2"></div>
-				</div>
-			</div>  
-		 <footer>
-		 	<p>
-		 		xHain hack+makespace <br>
-		 		Grünberger Straße 14  <br>
-		 		10243 Berlin		  <br><br>	 		
-				<a href="https://twitter.com/xHain_hackspace" >
-		 			<img src="/Twitter_logo.jpg" alt="xHain hack+makespace" height="16" width="16" title="Twitter">
-				</a>
-				<a href="mailto:x-hain@posteo.de?subject=Newsletter%20abonnieren">
-		 			<img src="/Mail_Icon.png" alt="xHain hack+makespace" height="24" width="24" title="Newsletter">
-				</a>
-	 		</p>
-	 	</footer>
-	</body>
-</html>
+<p>
+	<br>
+	There are several ways to support xHain. As we’ve only just started building the place, there are two main things you can contribute: time and money.
+</p>
+<h3>Coming Over</h3>
+<p>
+	Come over and help us! There are still shelves and tables to be built, a bathroom to be wallpapered, chairs to be painted, a cable harness to be built, window blinds to be put up, and things to be done in general. All helping hands are welcome! If you have one or two to spare, shoot Felix an email (<a href="mailto:x-hain@posteo.de">x-hain@posteo.de</a>) or tweet to us <a href="https://twitter.com/xHain_hackspace">@xhain_hackspace</a>.
+</p>
+<h3>Support Rate</h3>
+<p>
+	If you think it’s good and important to have a hackspace in Friedrichshain, support us! Our support rate sets you back €13.37 a month.
+	In return, you get discounts on everything we’ll have to offer in future. We’re planning to have t-shirts, workshops, training sessions, 3D prints and lots more. Supporters are also free to use our tools and devices such as the 3D printer.
+	If the support rate is beyond your means, talk to us and we’ll find a way.
+	Of course, you’re also free to support us with more than €13.37 and help sponsor somebody else’s membership.
+</p>
+<p>
+	Running a hackspace isn’t free: we need to pay rent, electricity, internet and other niceties. All proceeds from the support rate go towards our running costs. Should there be a surplus, we’ll use it to buy more tools and devices that keep turning our hackspace into <em>the</em> place to go for all tech enthusiasts in Friedrichshain.
+</p>
+<h3>Renting the Place</h3>
+<p>
+	You can rent xHain for a small conference or an event. There’s not enough room for huge birthday parties, but if you’re planning a workshop, if you’re looking for a less conventional place for your meetings, if you want to screen your movie or if you’re looking for a creative environment where you can write your fan fiction, just contact us and we’ll work out the details.
+</p>
+<h3>Donating Equipment</h3>
+<p>
+	If your laser cutters, soldering stations, 3D printers, screwdrivers, Arduinos, Raspberry Pis, rad1o badges or webcams are only collecting dust: give them to us! We’re thrilled to give a new home to all your old-but-functional gadgets and devices.
+</p>

--- a/support.html
+++ b/support.html
@@ -1,66 +1,25 @@
 ---
 lang: de
+layout: main
 ---
-<!DOCTYPE html>
-<html lang="de">
-	<head>
-		<meta charset="UTF-8">
-		<title>xHain hack+makespace</title>
-		<meta name="viewport" content="width=device-width, initial-scale=1">			 
-    	<link rel="stylesheet" 
-    			href="css/bootstrap.min.css" >
-		<link rel="stylesheet" 
-			  href="css/style.css">	
-	</head>
-	<body>
-		<header>
-			{% include navigation.html %}
-		</header>
-			<div class="container">
-				<div class="row">
-					<div class="col-md-2"></div>
-					<div class="col-md-8 center">
-						<section>
-							<article>
-								<br>
-								<p>
-								Es gibt verschiedene Möglichkeiten, den xHain Hackspace zu unterstützen. Da wir gerade erst in der Anfangs- und Aufbauphase sind, könnt ihr vor allem mit zwei Dingen helfen: Zeit und Geld.
-								</p> 
-								<h3>Vorbeikommen</h3>
-								<p>Komm’ vorbei und hilf mit! Es gibt immer noch Regale und Tische zu bauen, ein Bad zu tapezieren, Sitzgelegenheiten zu lackieren, ein Kabelbaum zu bauen, Jalousien anzubringen, und so weiter. Jede helfende Hand ist herzlich willkommen! Schreib bei Interesse eine kurze Mail an Felix (<a href="mailto:x-hain@posteo.de">x-hain@posteo.de</a>) oder ping uns auf Twitter an <a href="https://twitter.com/xHain_hackspace">@xhain_hackspace</a>. 
-								</p>	
-								<h3>Support-FlatRate</h3>
-								<p>Wenn du es für richtig und wichtig hältst, dass es in Friedrichshain einen Hackspace gibt, dann unterstütze uns!
-								Die Support-Flatrate kostet 13.37 Euro im Monat.
-								Dafür gibt es Rabatte und Vergünstigungen bei allem, was wir in Zukunft an (Gegen-)Wert schaffen. In Planung sind T-Shirts, Workshops, Weiterbildungen, 3D-Drucksachen und vieles mehr. Für die Unterstützenden ist darüber hinaus die Nutzung der vorhandenen Werkzeuge und Geräte (3D-Drucker u.ä.) umsonst. 
-								Sollte dir der Betrag finanziell nicht möglich sein, sprich uns bitte an, wir finden schon eine Lösung. 
-								Natürlich ist es auch möglich, uns mit mehr als 13,37 Euro im Monat zu unterstützen. Ein solcher Soli würde dann denjenigen zugute kommen, die sich die Support-Flatrate nicht leisten können.
-								Der Betrieb eines Hackspaces kostet Geld: Miete, Strom, Internet und so weiter. Alle Einnahmen aus der Support-Flatrate werden zur Zahlung der laufenden Kosten genutzt. Sollten diese Einnahmen die laufenden Kosten überschreiten, werden von den Überschüssen weitere Geräte und Werkzeuge angeschafft, die den Hackspace nach und nach in eine 1a Anlaufstelle für alle Technikinteressierten in Friedrichshain verwandeln.
-								</p>
-								<h3>Raum mieten</h3>
-								<p>Du kannst den xHain außerdem als Tagungsort oder Raum für Veranstaltungen mieten. Fette Geburtstagsparties gehen leider nicht, aber wenn du einen Workshop planst, einen unkonventionelleren Sitzungsort suchst, deinen Film vorführen willst oder in kreativer Umgebung deine Fan Fiction voran bringen willst, dann kontaktiere uns, und wir klären die Details. 
-									</p>
-								<h3>Sachspenden</h3>
-								<p>Wenn eure Laserfräsen, Lötstationen, 3D-Drucker, Schraubenzieher, Arduinos, Raspberry Pis, rad1o badges oder Webcams im Keller verstauben: Her damit! Wir bieten deinen alten, aber funktionstüchtigen Gerätschaften und Spielzeugen gern ein neues Zuhause. 
-								</p>
-							</article>		
-						</section> 
-					</div>
-					<div class="col-md-2"></div>
-				</div>
-			</div>  
-		 <footer>
-		 	<p>
-		 		xHain hack+makespace <br>
-		 		Grünberger Straße 14  <br>
-		 		10243 Berlin		  <br><br>	 		
-				<a href="https://twitter.com/xHain_hackspace" >
-		 			<img src="Twitter_logo.jpg" alt="xHain hack+makespace" height="16" width="16" title="Twitter">
-				</a>
-				<a href="mailto:x-hain@posteo.de?subject=Newsletter%20abonnieren">
-		 			<img src="Mail_Icon.png" alt="xHain hack+makespace" height="24" width="24" title="Newsletter">
-				</a>
-	 		</p>
-	 	</footer>
-	</body>
-</html>
+<br>
+<p>
+Es gibt verschiedene Möglichkeiten, den xHain Hackspace zu unterstützen. Da wir gerade erst in der Anfangs- und Aufbauphase sind, könnt ihr vor allem mit zwei Dingen helfen: Zeit und Geld.
+</p> 
+<h3>Vorbeikommen</h3>
+<p>Komm’ vorbei und hilf mit! Es gibt immer noch Regale und Tische zu bauen, ein Bad zu tapezieren, Sitzgelegenheiten zu lackieren, ein Kabelbaum zu bauen, Jalousien anzubringen, und so weiter. Jede helfende Hand ist herzlich willkommen! Schreib bei Interesse eine kurze Mail an Felix (<a href="mailto:x-hain@posteo.de">x-hain@posteo.de</a>) oder ping uns auf Twitter an <a href="https://twitter.com/xHain_hackspace">@xhain_hackspace</a>. 
+</p>	
+<h3>Support-FlatRate</h3>
+<p>Wenn du es für richtig und wichtig hältst, dass es in Friedrichshain einen Hackspace gibt, dann unterstütze uns!
+Die Support-Flatrate kostet 13.37 Euro im Monat.
+Dafür gibt es Rabatte und Vergünstigungen bei allem, was wir in Zukunft an (Gegen-)Wert schaffen. In Planung sind T-Shirts, Workshops, Weiterbildungen, 3D-Drucksachen und vieles mehr. Für die Unterstützenden ist darüber hinaus die Nutzung der vorhandenen Werkzeuge und Geräte (3D-Drucker u.ä.) umsonst. 
+Sollte dir der Betrag finanziell nicht möglich sein, sprich uns bitte an, wir finden schon eine Lösung. 
+Natürlich ist es auch möglich, uns mit mehr als 13,37 Euro im Monat zu unterstützen. Ein solcher Soli würde dann denjenigen zugute kommen, die sich die Support-Flatrate nicht leisten können.
+Der Betrieb eines Hackspaces kostet Geld: Miete, Strom, Internet und so weiter. Alle Einnahmen aus der Support-Flatrate werden zur Zahlung der laufenden Kosten genutzt. Sollten diese Einnahmen die laufenden Kosten überschreiten, werden von den Überschüssen weitere Geräte und Werkzeuge angeschafft, die den Hackspace nach und nach in eine 1a Anlaufstelle für alle Technikinteressierten in Friedrichshain verwandeln.
+</p>
+<h3>Raum mieten</h3>
+<p>Du kannst den xHain außerdem als Tagungsort oder Raum für Veranstaltungen mieten. Fette Geburtstagsparties gehen leider nicht, aber wenn du einen Workshop planst, einen unkonventionelleren Sitzungsort suchst, deinen Film vorführen willst oder in kreativer Umgebung deine Fan Fiction voran bringen willst, dann kontaktiere uns, und wir klären die Details. 
+</p>
+<h3>Sachspenden</h3>
+<p>Wenn eure Laserfräsen, Lötstationen, 3D-Drucker, Schraubenzieher, Arduinos, Raspberry Pis, rad1o badges oder Webcams im Keller verstauben: Her damit! Wir bieten deinen alten, aber funktionstüchtigen Gerätschaften und Spielzeugen gern ein neues Zuhause. 
+</p>


### PR DESCRIPTION
This change strips out all the duplicate markup from the individual pages and makes more use of the layout files in `_layouts/`.

It also solves the problem of only listing blog posts in the correct language on the index pages. This comes with two caveats:
- All blog posts **must have the `lang` property set in the metadata** to either `de` or `en`. Otherwise they will not appear in any list.
- The **permalink should be manually set** to either `/news/yyyy/mm/dd/title.html` or `/en/news/yyyy/mm/dd/title.html` for consistency and to make the language switcher work properly.
