### PR TITLE
Fix broken links between blog posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,55 @@
+xHain hack+makespace
+====================
+
+## Translation
+
+Translated versions of German pages have a `.en` before the file extension (this
+is a convention and not a requirement).
+
+Example:
+
+- German: `support.html`
+- English: `support.en.html`
+
+This is only to keep the files together internally. The public-facing pages
+(i.e. the ones *generated* by Jekyll) should instead be placed in
+language-specific directories (or the root directory `/` for German files).
+
+Example:
+
+- German: `/support.html`
+- English: `/en/support.html`
+
+Jekyll doesn't do this automatically, instead you have to manually set the
+`permalink` property in the metadata. See `support.en.html` for an example
+of what the metadata block of translated pages should look like.
+
+By default, all pages have a link to the translated version at the top right
+of the page. If the conventions above are followed, these can be generated
+automatically. Otherwise, the **links to translated pages can be overriden or
+disabled** using the `translations` metadata property.
+
+Examples:
+
+Consider a page at `/news/2016/01/01/beispiel.html`. Its English version can be
+found at `/en/news/2016/01/01/example.html` rather than `/en/…/beispiel.html`.
+To link the two:
+
+```yaml
+# In _posts/2016-01-01-beispiel.html:
+translations:
+  en: /en/news/2016/01/01/example.html
+
+# In _posts/2016-01-01-beispiel.en.html:
+translations:
+  de: /news/2016/01/01/beispiel.html
+```
+
+If a page doesn't have a translated version, you can disable the link by
+passing `false` instead of the URI, like so:
+
+```yaml
+# On a German-language page without an English translation:
+translations:
+  en: false
+```

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -3,7 +3,12 @@
 </p>
 {% if page.lang == 'en' %}
 <nav>
-	<p class="languages"><a href="{{ page.url | replace_first: '/en/', '/' }}" lang="de">Deutsch</a></p>
+	<p class="languages">
+		{% if page.translations.de != false %}
+		{% assign url = page.translations.de %}
+		<a href="{% if url %}{{ url }}{% else %}{{ page.url | replace_first: '/en/', '/' }}{% endif %}" lang="de">Deutsch</a>
+		{% endif %}
+	</p>
 	<ul>
 		<li>
 			<a href="{{site.url}}/en/calendar.html" class="{% if page.url == '/en/calendar.html' %}current{% endif %}">happening</a>
@@ -18,7 +23,12 @@
 </nav>
 {% else %}
 <nav>
-	<p class="languages"><a href="{{ page.url | replace_first: '/', '/en/' }}" lang="en">English</a></p>
+	<p class="languages">
+		{% if page.translations.en != false %}
+		{% assign url = page.translations.en %}
+		<a href="{% if url %}{{ url }}{% else %}{{ page.url | replace_first: '/', '/en/' }}{% endif %}" lang="en">English</a>
+		{% endif %}
+	</p>
 	<ul>
 		<li>
 			<a href="{{site.url}}/calendar.html" class="{% if page.url == '/calendar.html' %}current{% endif %}">anstehendes</a>

--- a/_posts/2016-04-18-hackspace statt Angst - Eröffnung am Freitag, den 13. Mai 2016.en.md
+++ b/_posts/2016-04-18-hackspace statt Angst - Eröffnung am Freitag, den 13. Mai 2016.en.md
@@ -5,6 +5,8 @@ meta: short description
 category: news
 lang: en
 permalink: /en/news/2016/04/18/opening.html
+translations:
+  de: "/news/2016/04/18/hackspace-statt-Angst-Eröffnung-am-Freitag,-den-13.-Mai-2016.html"
 ---
 We're celebrating the opening of xHain on Friday, 13 May!
 

--- a/_posts/2016-04-18-hackspace statt Angst - Eröffnung am Freitag, den 13. Mai 2016.md
+++ b/_posts/2016-04-18-hackspace statt Angst - Eröffnung am Freitag, den 13. Mai 2016.md
@@ -4,6 +4,8 @@ title: hackspace statt Angst - Eröffnung am Freitag, den 13. Mai 2016
 meta: short description
 category: news
 lang: de
+translations:
+  en: /en/news/2016/04/18/opening.html
 ---
 <p> Am Freitag, den 13. Mai feiern wir die Eröffnung des xHains! <br> Ab 18Uhr steht Euch die Tür offen. <br> Kommt vorbei und schaut euch an was aus dem kahlen Raum geworden ist und kassiert einen Aufkleber ein. <br>
 Musik und Getränke gibt es natürlich auch.

--- a/calendar.html
+++ b/calendar.html
@@ -1,6 +1,7 @@
 ---
 lang: de
 layout: main
+redirect_from: calender.html
 ---
 <ul>
 	<li><h2>Mai 2016</h2></li>

--- a/calender.html
+++ b/calender.html
@@ -1,4 +1,0 @@
----
-layout: redirect
-destination: calendar.html
----


### PR DESCRIPTION
As discussed previously, this adds the option to override the automatically-generated links to translated versions of a page. Since this adds quite a bit of logic to the template, I've added a README.md to document the options for translated pages.

It also switches to using the `jekyll-redirect-from` gem for generating redirects.
